### PR TITLE
fix type bugs

### DIFF
--- a/src/components/utils/Tree.js
+++ b/src/components/utils/Tree.js
@@ -58,25 +58,10 @@ const treeToJson = (tree) => {
             value = fn()
           } catch (e) {
             console.warn(`{ ${item.name}: ${item.value} } => ${e.message}`)
-            result['string'] = item.value
+            result[item.name] = item.value
             break
           }
-          let type = typeof value
-          if (['string', 'number', 'boolean'].indexOf(type) > -1) {
-            result[type] = value
-          } else if (type === 'object') {
-            let objectType = Object.prototype.toString.call(type)
-            if (objectType === '[object RegExp]') {
-              type = 'regexp'
-            } else if (objectType === '[object Array]') {
-              type = 'array'
-            } else {
-              type = 'object'
-            }
-            result[type] = value
-          } else {
-            result['string'] = item.value
-          }
+          result[item.name] = value
         } catch (e) {
           console.warn(`{ ${item.name}: ${item.value} } => ${e.message}`) // TODO 2.2 初始值异常，应该直接提示到页面上。
           result[item.name] = item.value


### PR DESCRIPTION
上次改没改好，导致 function 类型的 key 会变成 function 返回值类型
比如 abc:()=>[1,2] 生成数据会变为 object:[1,2]
It's my bad