### PR TITLE
修复-接口参数编辑页面默认标签页展示错误

### DIFF
--- a/src/components/editor/InterfaceSummary.jsx
+++ b/src/components/editor/InterfaceSummary.jsx
@@ -34,12 +34,13 @@ class InterfaceSummary extends Component {
     super(props)
     this.state = {
       bodyOption: BODY_OPTION.FORM_DATA,
-      requestParamsType: props.method === 'POST' ? REQUEST_PARAMS_TYPE.BODY_PARAMS : REQUEST_PARAMS_TYPE.QUERY_PARAMS
+      requestParamsType: props.itf.method === 'POST' ? REQUEST_PARAMS_TYPE.BODY_PARAMS : REQUEST_PARAMS_TYPE.QUERY_PARAMS
     }
     this.changeMethod = this.changeMethod.bind(this)
     this.changeHandler = this.changeHandler.bind(this)
     this.switchBodyOptions = this.switchBodyOption.bind(this)
     this.switchRequestParamsType = this.switchRequestParamsType.bind(this)
+    this.state.requestParamsType === REQUEST_PARAMS_TYPE.BODY_PARAMS && props.stateChangeHandler(this.state)
   }
   static contextTypes = {
     store: PropTypes.object.isRequired,


### PR DESCRIPTION
props.method为undefined，导致当编辑POST的接口时，默认的请求参数tab显示错误