### PR TITLE
README中增加Nginx配置文件信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,32 @@ npm run build
 serve -s ./build -p 80
 ```
 
+### production nginx conf file
+
+```config
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /xxxx/rap2-dolores/build;
+        try_files $uri /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+```
+
 ## Author
 
 * Owner: Alimama FE Team


### PR DESCRIPTION
增加Nginx配置文件信息，替代pm2 serve命令，测试能够正常刷新页面。