### PR TITLE
feature/add-docker-support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:stable-alpine 
 
-ADD ./build/ /usr/share/nginx/html/ 
+ADD ./build/ /usr/share/nginx/html/
+ADD default.conf /etc/nginx/conf.d/default.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:stable-alpine 
+
+ADD ./build/ /usr/share/nginx/html/ 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ serve -s ./build -p 80
 ```
 
 ### docker部署
-```
+```sh
 # 1. config server API path in /src/config/config.prod.js(production config file)
 # 1. 配置后端服务器的地址。 /src/config/config.prod.js(生产模式配置文件)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ npm run build
 serve -s ./build -p 80
 ```
 
+### docker部署
+```
+# 1. config server API path in /src/config/config.prod.js(production config file)
+# 1. 配置后端服务器的地址。 /src/config/config.prod.js(生产模式配置文件)
+
+# 2. run build-image.sh, make sure the server has docker installed.
+# 2. 执行构建镜像命令，确保环境上安装有docker（脚本会pull下来node镜像做npm的构建，然后基于nginx制作最终镜像）
+```
+
 ## Author
 
 * Owner: Alimama FE Team

--- a/build-image.sh
+++ b/build-image.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+CUR_DIR=`pwd`
+docker pull node:8.11.1-alpine
+docker run -itd -v ${CUR_DIR}:/app --name build-dolores -w /app node:8.11.1-alpine sh
+docker exec -it build-dolores sh -c "npm install && npm run build"
+docker build -t rap2-dolores:1.0.0 .
+docker rm -f build-dolores

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,46 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '2.2'
 
 services:
   dolores:
-    image: rap2-dolores:1.0.0
-    container_name: rap2-dolores
+    image: rap2-dolores:1.0.0  #示例镜像，需要根据实际情况更新    container_name: rap2-dolores
     ports:
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.2'
 
 services:
   dolores:
-    image: stpice/rap2-dolores:1.0.0
+    image: rap2-dolores:1.0.0
     container_name: rap2-dolores
     ports:
       - 80:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2.2'
 
 services:
   dolores:
-    image: rap2-dolores:1.0.0  #ç¤ºä¾‹é•œåƒï¼Œéœ€è¦æ ¹æ®å®é™…æƒ…å†µæ›´æ–°    container_name: rap2-dolores
-    ports:
+    image: rap2-dolores:1.0.0  #Ê¾Àı¾µÏñ£¬ĞèÒª¸ù¾İÊµ¼ÊÇé¿ö¸üĞÂ    container_name: rap2-dolores    ports:
       - 80:80
+    environment:
+      # todo: this is the backend api rap2-delos's url, this feature can make dolores read url from env.
+      - BACKEND_API_URL='http://rap2api.taobao.org'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2.2'
+
+services:
+  dolores:
+    image: stpice/rap2-dolores:1.0.0
+    container_name: rap2-dolores
+    ports:
+      - 80:80


### PR DESCRIPTION
增加了构建docker镜像的脚本，方便快速创建基于nginx的镜像，可以将docker-compose.yml文件中的内容和rap2-delos中的compose文件进行整合。
进一步可以将后端api的地址通过环境变量置入，可以提高配置的灵活性，这里需要其他开发者协助完成。